### PR TITLE
[FEAT] Create Summary Diary

### DIFF
--- a/src/app/diary/week/page.tsx
+++ b/src/app/diary/week/page.tsx
@@ -5,9 +5,30 @@ import * as S from './style';
 import WeekHeader from '@/features/diary/ui/WeekHeader';
 import WeekTable from '@/features/diary/ui/WeekTable';
 import { useWeekNavigator } from '@/features/diary/hooks/useWeekNavigator';
+import { useSummaryDiary } from '@/features/diary/queries/useSummaryDiary';
+import { AxiosError } from 'axios';
+import { useNotify } from '@/shared/lib/hooks/useNotify';
 
 export default function WeekPage() {
-  const { label, rangeText, prevWeek, nextWeek, diaryMeta } = useWeekNavigator();
+  const { label, rangeText, prevWeek, nextWeek, diaryMeta, rangeQuery } = useWeekNavigator();
+
+  const toast = useNotify();
+
+  const { mutate, isLoading } = useSummaryDiary();
+
+  const summaryTrigger = () => {
+    mutate(
+      { start: rangeQuery.from, end: rangeQuery.to },
+      {
+        onSuccess: (data) => {
+          toast.success(data.message);
+        },
+        onError: (error: AxiosError<{ message: string }>) => {
+          toast.warning(error.response.data.message);
+        },
+      }
+    );
+  };
 
   return (
     <S.Wrapper>
@@ -17,7 +38,8 @@ export default function WeekPage() {
         isDisabled={!diaryMeta || diaryMeta.length === 0}
         prevWeekAction={prevWeek}
         nextWeekAction={nextWeek}
-        onGenerateSummaryAction={() => console.log('Generate Summary')}
+        onGenerateSummaryAction={summaryTrigger}
+        isLoading={isLoading}
       />
 
       <WeekTable diaryMeta={diaryMeta ?? []} />

--- a/src/features/diary/api/promise.ts
+++ b/src/features/diary/api/promise.ts
@@ -8,6 +8,7 @@ import {
 import { UpsertDiaryContentResponseDTO } from '@/features/diary/model/response/upsertDiaryContent';
 import { GetWeekDiaryMetaForm } from '@/features/diary/model/request/getWeekDiaryMeta';
 import { GetWeekDiaryMetaResponseDTO } from '@/features/diary/model/response/getWeekDiaryMeta';
+import { SummaryDiaryForm, SummaryDiaryRequestDTO } from '@/features/diary/model/request/summaryDiary';
 
 export const logout = () => {
   return SHIORI_BE.delete('/user/logout');
@@ -28,4 +29,13 @@ export const upsertDiaryContent = ({ date, content, title }: UpsertDiaryContentF
 
 export const getWeekDiaryMeta = ({ startDate, endDate }: GetWeekDiaryMetaForm) => {
   return SHIORI_BE.get<GetWeekDiaryMetaResponseDTO>(`/diary?start=${startDate}&end=${endDate}`);
+};
+
+export const summaryDiary = ({ start, end }: SummaryDiaryForm) => {
+  const body = {
+    start: start,
+    end: end,
+  };
+
+  return SHIORI_BE.post<SummaryDiaryRequestDTO, null>(`/diary/summary`, body);
 };

--- a/src/features/diary/hooks/useWeekNavigator.ts
+++ b/src/features/diary/hooks/useWeekNavigator.ts
@@ -57,7 +57,7 @@ export const useWeekNavigator = (initial?: Date): WeekNavigator => {
     label: getMonthWeekLabel(weekStart),
     rangeText: `${formattedStart} ~ ${formattedEnd}`,
     days,
-    rangeQuery: { from: formattedStart, to: formattedEnd },
+    rangeQuery: { from: startDate, to: endDate },
     prevWeek,
     nextWeek,
     goToday,

--- a/src/features/diary/model/request/summaryDiary.ts
+++ b/src/features/diary/model/request/summaryDiary.ts
@@ -2,3 +2,5 @@ export type SummaryDiaryForm = {
   start: string;
   end: string;
 };
+
+export type SummaryDiaryRequestDTO = SummaryDiaryForm;

--- a/src/features/diary/model/request/summaryDiary.ts
+++ b/src/features/diary/model/request/summaryDiary.ts
@@ -1,0 +1,4 @@
+export type SummaryDiaryForm = {
+  start: string;
+  end: string;
+};

--- a/src/features/diary/queries/useSummaryDiary.ts
+++ b/src/features/diary/queries/useSummaryDiary.ts
@@ -1,0 +1,17 @@
+import { useMutation } from '@tanstack/react-query';
+import { summaryDiary } from '@/features/diary/api/promise';
+import { SummaryDiaryForm } from '@/features/diary/model/request/summaryDiary';
+
+export const useSummaryDiary = () => {
+  const mutation = useMutation({
+    mutationFn: async ({ start, end }: SummaryDiaryForm) => {
+      const response = await summaryDiary({
+        start: start,
+        end: end,
+      });
+      return response.data;
+    },
+  });
+
+  return mutation;
+};

--- a/src/features/diary/ui/WeekHeader.tsx
+++ b/src/features/diary/ui/WeekHeader.tsx
@@ -13,6 +13,7 @@ type Props = {
   prevWeekAction: () => void;
   nextWeekAction: () => void;
   onGenerateSummaryAction: () => void;
+  isLoading: boolean;
 };
 
 export default function WeekHeader({
@@ -22,6 +23,7 @@ export default function WeekHeader({
   onGenerateSummaryAction,
   nextWeekAction,
   prevWeekAction,
+  isLoading,
 }: Props) {
   return (
     <HeaderBar>
@@ -38,6 +40,7 @@ export default function WeekHeader({
             backgroundColor={colors.secondary['500']}
             onClick={onGenerateSummaryAction}
             isDisabled={isDisabled}
+            isLoading={isLoading}
           >
             주간 요약 생성
           </Button>


### PR DESCRIPTION
### Change

- Defined `SummaryDiaryForm` and aliased it as `SummaryDiaryRequestDTO`
- Implemented `summaryDiary` API function to call `/diary/summary`
- Added `useSummaryDiary` mutation hook for summary requests
- Connected summary trigger logic in `WeekPage` using the mutation

### Note

- The summary button is enabled only when all 7 diary entries exist
- Success and error messages are displayed via toast notifications